### PR TITLE
Ubl 20161031

### DIFF
--- a/ubl_batch_ingest_datastreams/includes/ubl_batch_ingest_datastreams_zip_import.form.inc
+++ b/ubl_batch_ingest_datastreams/includes/ubl_batch_ingest_datastreams_zip_import.form.inc
@@ -23,7 +23,6 @@ function ubl_batch_ingest_datastreams_import_form(array $form, array &$form_stat
 }
 
 function ubl_batch_ingest_datastreams_import_form_submit(array $form, array &$form_state) {
-  $form_state['rebuild'] = TRUE;
   if (isset($_SESSION['ubl_batch_ingest_datastreams_ingest_objects'])) {
     return ubl_batch_ingest_datastreams_confirm_form_submit($form, $form_state);
   }
@@ -56,7 +55,7 @@ function ubl_batch_ingest_datastreams_import_zip_or_csv_form(array $form, array 
   );
   $form['submit'] = array(
     '#type' => 'submit',
-    '#value' => t('Upload'),
+    '#value' => t('Ingest datastreams'),
   );
   return $form;
 }
@@ -279,7 +278,7 @@ function ubl_batch_ingest_datastreams_confirm_form(array $form, array &$form_sta
         $is_collection = FALSE;
         $options[$key]['objectid'] = check_plain($objectid);
         if (array_key_exists('object', $values)) {
-          $object = $values["object"];
+          $object = $values['object'];
           $is_collection = in_array('islandora:collectionCModel', $object->models);
           $options[$key]['object'] = array(
             'data' => array(
@@ -351,7 +350,7 @@ function ubl_batch_ingest_datastreams_confirm_form(array $form, array &$form_sta
 
     $form['cancel'] = array(
       '#type' => 'submit',
-      '#value' => t('Cancel'),
+      '#value' => t('Back to upload'),
     );
     if (!$_SESSION['ubl_batch_ingest_datastreams_finished']) {
       $form['submit'] = array(
@@ -359,10 +358,6 @@ function ubl_batch_ingest_datastreams_confirm_form(array $form, array &$form_sta
         '#value' => t('Ingest datastreams'),
       );
     }
-  }
-  if ($_SESSION['ubl_batch_ingest_datastreams_finished']) {
-    unset($_SESSION['ubl_batch_ingest_datastreams_ingest_objects']);
-    unset($_SESSION['ubl_batch_ingest_datastreams_finished']);
   }
 
   return $form;
@@ -555,6 +550,10 @@ function find_fedora_object_ids($identifier, $query_field = "catch_all_fields_mt
 
     if ($objid) {
       $objectids[] = $objid;
+      if (count($objectids) > 1) {
+        // Limit the number of object ids found to 2, because it is not useful to find more.
+        break;
+      }
     }
   }
 

--- a/ubl_metadata_synchronization/includes/synchronize.inc
+++ b/ubl_metadata_synchronization/includes/synchronize.inc
@@ -23,7 +23,15 @@ function ubl_metadata_synchronization_sync_metadata_for_object_using(AbstractObj
     );
   }
 
-  $xml = ubl_metadata_synchronization_xsl_transform($oaimdxml, $mdxsl);
+  $parameters = array();
+  if ($dsid === 'MODS') {
+    // Keep the handle that is stored in the MODS datastream.
+    $handle = ubl_metadata_synchronization_get_handle($object);
+    if ($handle) {
+      $parameters['handle'] = $handle;
+    }
+  }
+  $xml = ubl_metadata_synchronization_xsl_transform($oaimdxml, $mdxsl,$parameters);
 
   if (!$xml) {
     return t("Could not create @dsid for object @objid with sync id @syncid",
@@ -87,13 +95,17 @@ function ubl_metadata_synchronization_save_xml(AbstractObject $object, $xml, $ds
 /**
  * Transform XML as a string by using XSL as a file.
  */
-function ubl_metadata_synchronization_xsl_transform($xml, $xslfile) {
+function ubl_metadata_synchronization_xsl_transform($xml, $xslfile, $parameters = array()) {
   $xsl = new DOMDocument();
   $xsl->load($xslfile);
   $input = new DOMDocument();
   $input->loadXML($xml);
   $processor = new XSLTProcessor();
   $processor->importStylesheet($xsl);
+
+  foreach ($parameters as $parkey => $parvalue) {
+    $processor->setParameter('',$parkey,$parvalue);
+  }
 
   // XXX: Suppressing warnings regarding unregistered prefixes.
   return trim(@$processor->transformToXML($input));
@@ -456,4 +468,31 @@ function find_fedora_object_for_id($id) {
   }
 
   return FALSE;
+}
+
+/**
+ * Retrieve the handle for this object.
+ */
+function ubl_metadata_synchronization_get_handle($object) {
+  $handle = FALSE;
+  if (isset($object['MODS'])) {
+    $xpath = "/mods:mods/mods:identifier[@type='hdl']";
+    $content = $object['MODS']->content;
+    $domdoc = new DOMDocument();
+    if ($domdoc->loadXML($content)) {
+      $domxpath = new DOMXPath($domdoc);
+      $domxpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+      $domnodelist = $domxpath->query($xpath);
+      if ($domnodelist->length > 0) {
+        foreach ($domnodelist as $domnode) {
+          $text = $domnode->textContent;
+          if (isset($text) && strlen($text) > 0) {
+            $handle = $text;
+            break;
+          }
+        }
+      }
+    }
+  }
+  return $handle;
 }

--- a/ubl_metadata_synchronization/xsl/OAIMARC2MODS.xsl
+++ b/ubl_metadata_synchronization/xsl/OAIMARC2MODS.xsl
@@ -114,7 +114,7 @@ Revision 1.03 - Additional Changes not related to MODS Version 2.0 by ntra
 Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 	-->
 
-
+       <xsl:param name="handle"/>
        <xsl:variable name="oaiid" select="//oai:identifier"/>
 
 
@@ -134,6 +134,14 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
 					<xsl:for-each select="//marc:record">
 						<xsl:call-template name="marcRecord"/>
 					</xsl:for-each>
+                                        <xsl:if test="$handle">
+                                          <xsl:if test="not(starts-with(//marc:datafield[@tag='856']/marc:subfield[@code='u'],'urn:hdl') or starts-with(//marc:datafield[@tag='856']/marc:subfield[@code='u'],'hdl') or starts-with(//marc:datafield[@tag='856']/marc:subfield[@code='u'],'http://hdl.loc.gov'))">
+                                            <identifier>
+                                              <xsl:attribute name="type"><xsl:value-of select="'hdl'"/></xsl:attribute>
+                                              <xsl:value-of select="$handle"/>
+                                            </identifier>
+                                          </xsl:if>
+                                        </xsl:if>
 				</mods>
 			</xsl:otherwise>
 		</xsl:choose>


### PR DESCRIPTION
- textual improvements
- don't remove session variables on finish, but on explicit command of
user
- limit number of found objects per id to 2, because more is not needed